### PR TITLE
OrderedDict compatible

### DIFF
--- a/jsonweb/__init__.py
+++ b/jsonweb/__init__.py
@@ -1,3 +1,2 @@
-from jsonweb.decode import loader, from_object
-from jsonweb.encode import dumper, to_object
-
+from .decode import loader, from_object
+from .encode import dumper, to_object

--- a/jsonweb/decode.py
+++ b/jsonweb/decode.py
@@ -199,10 +199,10 @@ class ObjectHook(object):
     directly. :func:`object_hook` is responsible for instantiating and using it.
     """
 
-    def __init__(self, handlers, validate=True,baseHook=None):
+    def __init__(self, handlers, validate=True, base_hook=None):
         self.handlers = handlers
         self.validate = validate
-        self.baseHook = baseHook
+        self.baseHook = base_hook
 
 
     def decode_obj(self, obj):

--- a/jsonweb/validators.py
+++ b/jsonweb/validators.py
@@ -2,10 +2,10 @@
 import inspect
 import re
 from datetime import datetime
-from jsonweb import encode
+from . import encode
 
-from jsonweb.py3k import basestring, items
-from jsonweb.exceptions import JsonWebError
+from .py3k import basestring, items
+from .exceptions import JsonWebError
 
 
 class _Errors(object):


### PR DESCRIPTION
It seems there are 3 changes here.
Firstly, my editor (atom) likes to delete training whitespace at the end of lines. Annoying and distracting, since it creates a lot of lines with changes that are not really changes. My diff engine did not even highlight these lines as changed.

Secondly, I moved to relative imports as this give flexibility where the package is in the tree.

Thirdly, and most significantly, I added code to allow working with 'OrderedDict' which allow maintaining the order of key value pairs.  So dictionaries which are not classes can be returned as OrderedDicts when passing method to 'object_hook_pair'.  Previously any use of 'object_hook_pairs' blocked object decoding.  I modified the code to still work with object hook_pairs.

Hope you like the addition.