### PR TITLE
Fix serialisation when constructor has py3 type annotations

### DIFF
--- a/jsonweb/decode.py
+++ b/jsonweb/decode.py
@@ -231,7 +231,7 @@ class ObjectHook(object):
         
 
 def get_arg_spec(func):
-    arg_spec = inspect.getargspec(func)
+    arg_spec = inspect.getfullargspec(func)
     args = arg_spec.args
     
     try:   

--- a/jsonweb/tests/test_decode.py
+++ b/jsonweb/tests/test_decode.py
@@ -355,4 +355,16 @@ class TestJsonWebObjectDecoder(unittest.TestCase):
                     
             self.assertEqual(decode._as_type_context.top, Person)
 
-        self.assertEqual(decode._as_type_context.top, None)        
+        self.assertEqual(decode._as_type_context.top, None)
+
+    def test_decode_with_py3_type_annotation(self):
+        @decode.from_object()
+        class Person:
+            def __init__(self, name: str):
+                self.name = name
+
+        json_str = '{"__type__": "Person", "name": "shawn"}'
+        person = loader(json_str)
+
+        self.assertTrue(isinstance(person, Person))
+        self.assertEqual(person.name, "shawn")

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '0.8.2'
+version = '0.8.3'
 
 if os.path.exists("README.rst"):
     long_description = open("README.rst").read()


### PR DESCRIPTION
By using `getfullargspec` instead of the deprecated `getargspec`. Classes like this now work:

```
class Person:
     def __init__(self, name: str):
         self.name = name
```

-----
PS I'm running Python 3.6. This won't work on 2.7 as it is, but it can be done. How important is it to support 2.7?